### PR TITLE
Fixing password leak

### DIFF
--- a/truenascsp/backend.py
+++ b/truenascsp/backend.py
@@ -84,7 +84,8 @@ class Handler:
         self.logger.debug('       query: %s', req.query_string)
         self.logger.debug('      method: %s', req.method)
         self.logger.debug('content_type: %s', req.content_type)
-        self.logger.debug('     headers: %s', json.dumps(req.headers))
+        headers = json.dumps(req.headers).replace(self.token, "*****")
+        self.logger.debug('     headers: %s', headers)
 
     def url_tmpl(self, uri):
         return '{schema}://{backend}{api}{uri}'.format(schema=self.backend_schema,


### PR DESCRIPTION
Fixes #8 

Output now removes the sensitive password/api key with `*`'s:
`Thu, 25 Feb 2021 04:06:02 +0000 backend DEBUG      headers: {"HOST": "truenas-csp:8080", "USER-AGENT": "Go-http-client/1.1", "CONNECTION": "close", "ACCEPT": "application/json", "CONTENT-TYPE": "application/json", "X-ARRAY-IP": "freenas.host", "X-AUTH-TOKEN": "*****", "ACCEPT-ENCODING": "gzip"}`