### PR TITLE
Add workaround for Truenas Scale 25

### DIFF
--- a/helm/charts/truenas-csp/Chart.yaml
+++ b/helm/charts/truenas-csp/Chart.yaml
@@ -12,8 +12,8 @@ annotations:
     - name: Install
       url: https://github.com/hpe-storage/truenas-csp/blob/master/INSTALL.md
   artifacthub.io/prerelease: "false"
-version: "1.2.1"
-appVersion: "2.5.2"
+version: "1.2.2"
+appVersion: "2.5.3"
 maintainers:
   - name: Michael Mattsson
     email: michael.mattsson@gmail.com

--- a/helm/charts/truenas-csp/templates/deployment.yaml
+++ b/helm/charts/truenas-csp/templates/deployment.yaml
@@ -31,11 +31,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.images.trueNasCSP }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{ if .Values.logDebug -}}
           env:
+            {{ if .Values.logDebug -}}
             - name: LOG_DEBUG
               value: "1"
-          {{- end }}
+            {{- end }}
+            {{ if .Values.forceTruenasScale -}}
+            - name: FORCE_TRUENAS_SCALE
+              value: "1"
+            {{- end }}
           {{ if eq .Values.optimizeFor "FreeNAS" -}}
           command:
             - /app/bin/gunicorn

--- a/helm/charts/truenas-csp/values.schema.json
+++ b/helm/charts/truenas-csp/values.schema.json
@@ -29,6 +29,13 @@
         "logDebug": {
             "$id": "#/properties/logDebug",
             "type": "boolean",
+            "title": "Override truenas version to SCALE",
+            "description": "Override truenas version to SCALE.",
+            "default": false
+        },
+        "forceTruenasScale": {
+            "$id": "#/properties/forceTruenasScale",
+            "type": "boolean",
             "title": "The logDebug schema",
             "description": "An explanation about the purpose of this instance.",
             "default": false

--- a/helm/charts/truenas-csp/values.yaml
+++ b/helm/charts/truenas-csp/values.yaml
@@ -5,6 +5,8 @@
 
 # VERY verbose
 logDebug: false
+# Override truenas version to SCALE
+forceTruenasScale: false
 
 # Tunes the CSP backend API requests
 optimizeFor: "Default"
@@ -13,7 +15,7 @@ optimizeFor: "Default"
 imagePullPolicy: IfNotPresent
 
 images:
-  trueNasCSP: quay.io/datamattsson/truenas-csp:v2.5.2
+  trueNasCSP: quay.io/datamattsson/truenas-csp:v2.5.3
 
 imagePullSecrets: []
 nameOverride: ""

--- a/truenascsp/backend.py
+++ b/truenascsp/backend.py
@@ -59,8 +59,9 @@ class Handler:
         self.clone_from_pvc_prefix = 'snap-for-clone-'
 
         self.logger = logging.getLogger('{name} {pid}'.format(name=__name__, pid=getpid()))
-        self.logger.setLevel(logging.DEBUG if environ.get(
-            'LOG_DEBUG') else logging.INFO)
+        self.logger.setLevel(logging.DEBUG if environ.get('LOG_DEBUG') else logging.INFO)
+
+        self.forceTruenasScale = True if environ.get('FORCE_TRUENAS_SCALE') else False
 
         self.dataset_defaults = {
             'deduplication': environ.get('DEFAULT_DEDUPLICATION', 'OFF'),
@@ -137,6 +138,10 @@ class Handler:
     def version(self):
         version = self.fetch('system/version')
         self.logger.debug('Version: %s', version)
+        
+        if self.forceTruenasScale:
+            self.logger.warning('Force SCALE version')
+            return "SCALE"
 
         if "TrueNAS-SCALE" in version:
             return "SCALE"


### PR DESCRIPTION
In 25 version was changed result of `system/version`
```
$ curl 'https://192.168.1.100/api/v2.0/system/version' --user root:xxxxx -k
"TrueNAS-25.04.2.1"
```

In CSP 2.5.2 all `TrueNAS-XXXXXX` detected as `CORE`.
`CORE` version accept `auth_network: []` in `/api/v2.0/iscsi/initiator` but `SCALE` return 422 err 
```json
{
 "iscsi_initiator_create.auth_network": [
  {
   "message": "Extra inputs are not permitted",
   "errno": 22
  }
 ]
}
```

Add way to force truenas instance type
```shell
$ cat chart-values_hpe-csi-truenas-csp.yml 
images:
  trueNasCSP: registry.arkprojects.space/apps/truenas-csp:v2.5.3
imagePullSecrets:
  - name: harbor-registry-pull-secret

logDebug: true
forceTruenasScale: true
```