### PR TITLE
fix: helm chart error when logsDebug is true

### DIFF
--- a/helm/charts/truenas-csp/templates/deployment.yaml
+++ b/helm/charts/truenas-csp/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           env:
             - name: DEFAULT_TARGET_PORTAL
               value: "{{ .Values.targetPortal }}"
-          {{ if .Values.logDebug -}}
+          {{- if .Values.logDebug }}
             - name: LOG_DEBUG
               value: "1"
           {{- end }}


### PR DESCRIPTION
Enabling debug logs in values ​​causes deployment rendering to fail. This PR fixes the error caused by wrong whitespace removal.

Step to reproduce the error:

`helm template truenas-csp/truenas-csp --set logDebug=true`